### PR TITLE
Updated types and data to fix rendering

### DIFF
--- a/components/FlightCard.tsx
+++ b/components/FlightCard.tsx
@@ -1,18 +1,14 @@
-import React, { useState, useRef } from "react";
-import { ItemTypes } from "./Constants";
-import { useDrag } from "react-dnd";
-import { Button } from "./ui/button";
-import { FlightResponseData } from "@/lib/route-types";
-import { getMinCost } from "@/lib/utils";
+import { AvailabilitySegment, FlightOptionWIndex } from "@/lib/availability-types";
+import React, { useRef, useState } from "react";
+
 import Image from "next/image";
+import { ItemTypes } from "./Constants";
 import svg from "../public/drag-handle.svg";
-import airlines from "@/lib/airlines";
-import { FlightOption } from "@/lib/availability-types";
+import { useDrag } from "react-dnd";
 
 // Update props
 type Props = {
-  item?: any;
-  data?: FlightOption;
+  item: FlightOptionWIndex;
   description?: string;
   title?: string;
   id: number;
@@ -20,10 +16,17 @@ type Props = {
   handleRemove: (id: number) => void;
 };
 
+const getOriginAirport = (segments: AvailabilitySegment[]) => {
+  return segments[0].OriginAirport;
+}
+
+const getDestinationAirport = (segments: AvailabilitySegment[]) => {
+  return segments[segments.length - 1].DestinationAirport;
+}
+
 function FlightCard(props: Props) {
   const [showModal, setModal] = useState(false);
   const ref = useRef<any>(null);
-  // const [card, setCard] = useState<any | null>();
   const handleClick = () => {
     window.scrollTo({ top: 0, behavior: "auto" });
   };
@@ -31,10 +34,7 @@ function FlightCard(props: Props) {
   const handleClick2 = () => {
     ref.current?.scrollIntoView({ behavior: "auto" });
   };
-
-  function displayModal(card: any, setModal: any, item: any) {
-    // console.log(item);
-    let flightOptions = ["F", "J", "W", "Y"];
+  const displayModal = (props: Props, setModal: React.Dispatch<React.SetStateAction<boolean>>, item: FlightOptionWIndex) => {
     return (
       <div className="z-40 drop-shadow-lg text-black h-[100vh] absolute top-0 left-0 flex justify-center items-center w-screen bg-slate-600/80">
         <div className="w-[50vw] h-[50vh] p-8 pb-10 border-solid b-1 border-slate-200 bg-white relative rounded-lg">
@@ -53,71 +53,27 @@ function FlightCard(props: Props) {
             {"Flight: " + (item.idx + 1)}
           </div>
           <div className="text-base text-center font-normal">
-            Date: {item.Date}
+            Date: {item.DepartsAt}  {/*  TODO: may not be what we want to display */}
           </div>
           <div className="text-base text-center font-normal">
-            From: {item.Route.OriginAirport} to {item.Route.DestinationAirport}
+            From: {getOriginAirport(item.AvailabilitySegments)} to {getDestinationAirport(item.AvailabilitySegments)}
           </div>
           <div className="text-lg font-normal text-center mb-2">
             Flight Options
           </div>
           <div className="grid grid-rows-2 grid-cols-2 gap-4">
-            {flightOptions.map((element) => {
-              const airline =
-                element == "F"
-                  ? item.FAirlines
-                  : element == "J"
-                  ? item.JAirlines
-                  : element == "W"
-                  ? item.WAirlines
-                  : item.YAirlines;
-              const direct =
-                element == "F"
-                  ? item.FDirect
-                  : element == "J"
-                  ? item.JDirect
-                  : element == "W"
-                  ? item.WDirect
-                  : item.YDirect;
-              const seats =
-                element == "F"
-                  ? item.FRemainingSeats
-                  : element == "J"
-                  ? item.JRemainingSeats
-                  : element == "W"
-                  ? item.WRemainingSeats
-                  : item.YRemainingSeats;
-              const points =
-                element == "F"
-                  ? item.FMileageCost
-                  : element == "J"
-                  ? item.JMileageCost
-                  : element == "W"
-                  ? item.WMileageCost
-                  : item.YMileageCost;
-              if (airline == "") {
-                return <div className="hidden"></div>;
-              }
-              return (
                 <div className="w-auto border-slate-400 border text-sm h-auto p-2 rounded-md">
                   <div className="text-sm font-semibold">
-                    {/* {airlines.find((element) => {
-                      if (element.code == airline) {
-                        return element.airline;
-                      }
-                    })} */}
-                    Airline: {airline}
+                    Airline: {item.Carriers}
                   </div>
                   <div className="text-sm font-normal">
-                    Direct Flight: {direct ? "Yes" : "No"}
+                    Direct Flight: {item.Stops === 0 ? "Yes" : "No"}
                   </div>
                   <div className="text-sm font-normal">
-                    Remaining Seats: {seats}
+                    Remaining Seats: {item.RemainingSeats}
                   </div>
-                  <div className="text-sm font-normal">Points: {points}</div>
+                  <div className="text-sm font-normal">Points: {item.MileageCost}</div>
                 </div>
-              );
-            })}
           </div>
         </div>
       </div>
@@ -175,7 +131,7 @@ function FlightCard(props: Props) {
         </div>
         <div className="text-lg">{"Flight: " + (props.item.idx + 1)}</div>
         <div className="text-sm font-light">
-          {"Points: " + getMinCost(props.item)}
+          {"Points: " + props.item.MileageCost }
         </div>
         {props.x == false ? (
           <div className=" text-xs font-thin">Click for details</div>

--- a/components/FlightStore.tsx
+++ b/components/FlightStore.tsx
@@ -1,10 +1,11 @@
+import { FlightOption, FlightOptionWIndex } from "@/lib/availability-types";
+import React, { useEffect, useState } from "react";
 import { User, useSupabaseClient, useUser } from "@supabase/auth-helpers-react";
-import React, { useState, useEffect } from "react";
+
 import FlightCard from "./FlightCard";
-import { useDrop } from "react-dnd";
-import { ItemTypes } from "./Constants";
 import { FlightResponseData } from "@/lib/route-types";
-import { FlightOption } from "@/lib/availability-types";
+import { ItemTypes } from "./Constants";
+import { useDrop } from "react-dnd";
 
 // TODO
 // These cards are flight cards and should be pulled from the flights that the user searches for
@@ -84,7 +85,7 @@ function FlightStore(props: Props) {
     }),
   }));
 
-  const FlightList = props.data.map((item, idx) => ({
+  const FlightList: FlightOptionWIndex[] = props.data.map((item, idx) => ({
     ...item,
     idx: idx,
   }));

--- a/lib/availability-types.ts
+++ b/lib/availability-types.ts
@@ -1,10 +1,10 @@
-interface BookingLink {
+type BookingLink = {
     label: string;
     link: string;
     primary: boolean;
 }
 
-interface AvailabilitySegment {
+type AvailabilitySegment = {
     ID: string;
     RouteID: string;
     AvailabilityID: string;
@@ -24,7 +24,7 @@ interface AvailabilitySegment {
     Order: number;
 }
 
-interface FlightOption {
+type FlightOption = {
     ID: string;
     RouteID: string;
     AvailabilityID: string;
@@ -48,16 +48,18 @@ interface FlightOption {
     Source: string;
 }
 
-interface CoordinateData {
+type FlightOptionWIndex = FlightOption & { idx: number };
+
+type CoordinateData = {
     Lat: number;
     Lon: number;
 }
 
-interface AvailabilityResponseData {
+type AvailabilityResponseData = {
     data: FlightOption[];
     origin_coordinates: CoordinateData;
     destination_coordinates: CoordinateData;
     booking_links: BookingLink[];
 }
 
-export type { AvailabilityResponseData, CoordinateData, FlightOption, BookingLink, AvailabilitySegment }
+export type { AvailabilityResponseData, CoordinateData, FlightOption, BookingLink, AvailabilitySegment, FlightOptionWIndex }

--- a/lib/requestHandler.ts
+++ b/lib/requestHandler.ts
@@ -1,5 +1,5 @@
-import { BasicFlightRequest, FlightResponseData } from "./route-types";
 import { AvailabilityResponseData, FlightOption } from "./availability-types";
+import { BasicFlightRequest, FlightResponseData } from "./route-types";
 
 /* This file contains a list of functions that should be called from the frontend */
 
@@ -41,6 +41,7 @@ async function fetchFlights(data: BasicFlightRequest) : Promise<FlightOption[]> 
 
     } catch (error) {
         // TODO: handle error
+        return []
     }
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,17 +1,4 @@
-import { User, useSupabaseClient, useUser } from "@supabase/auth-helpers-react";
-import { useEffect, useState, useRef } from "react";
-import { Button } from "@/components/ui/button";
-import { DndProvider } from "react-dnd";
-import { Input } from "@/components/ui/input";
-import { HTML5Backend } from "react-dnd-html5-backend";
-import { TouchBackend } from "react-dnd-touch-backend";
-import FlightStore from "@/components/FlightStore";
-import FlightStoreMobile from "@/components/FlightStoreMobile";
-
-import { FlightRequestForm } from "@/components/FlightRequestForm";
-import Navbar from "@/components/Navbar";
-import { getMinCost } from "@/lib/utils";
-import { useRouter } from "next/router";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   NavigationMenu,
   NavigationMenuContent,
@@ -22,8 +9,18 @@ import {
   NavigationMenuTrigger,
   NavigationMenuViewport,
 } from "@/components/ui/navigation-menu";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { User, useSupabaseClient, useUser } from "@supabase/auth-helpers-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { DndProvider } from "react-dnd";
 import { FlightOption } from "@/lib/availability-types";
+import { FlightRequestForm } from "@/components/FlightRequestForm";
+import FlightStore from "@/components/FlightStore";
+import FlightStoreMobile from "@/components/FlightStoreMobile";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { Input } from "@/components/ui/input";
+import { useRouter } from "next/router";
 
 export const dynamic = "force-dynamic"; // TODO: this was here for a reason, figure out why
 
@@ -185,7 +182,7 @@ export default function Home() {
     );
   }
 
-  function renderDragCards(data: FlightOptions) {
+  function renderDragCards(data: FlightOption[]) {
     return (
       <DndProvider backend={HTML5Backend}>
         <div className="flex flex-row justify-center h-auto -m-10">
@@ -195,7 +192,7 @@ export default function Home() {
     );
   }
 
-  function renderMobileCards(data: FlightOptions) {
+  function renderMobileCards(data: FlightOption[]) {
     return (
       <div>
         <FlightStoreMobile data={data} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@dnd-kit/core':
     specifier: ^6.1.0
@@ -2397,7 +2393,6 @@ packages:
   /elysia@0.8.17(openapi-types@12.1.3)(typescript@5.3.3):
     resolution: {integrity: sha512-hqKHKUxbvlDHnobudtna5nBoGiZ4oa0xdnhynLAJF3+6gTYHAcQ/8/IyxUx5Az5Uy0zTuNiv7m2bIFu7xeMiWg==}
     peerDependencies:
-      '@sinclair/typebox': '>= 0.31.0'
       openapi-types: '>= 12.0.0'
       typescript: '>= 5.0.0'
     peerDependenciesMeta:
@@ -5415,3 +5410,7 @@ packages:
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
done:

- fixed some typing cross card flow
- cleaned up displayModal to use the correct data, calling either from the FlightOption data or diving into AvailabilitySegment as needed

TODO:

- @jackheuberger stop using `interface` and start using `type`
- @vinayvis821 duplicate changes to mobile version
- @vinayvis821 change UI to only anticipate one flight now, or show the segments if there are multiple. no need for the "J" etc etc names, those don't come back bc we already select on them upstream (@jackheuberger do we just grab all of them?)
- pre filter on flights to show fewer of them, or fix the modal popup so things dont slide off the screen when there are too many